### PR TITLE
Update to pom.xml to prevent java.lang.NoSuchMethodError: java.nio.By…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <aws.kpl.version>0.15.7</aws.kpl.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
…teBuffer.rewind()Ljava/nio/ByteBuffer

*Issue #, if available:*
The code when compiled and run in emr-notebook environment, fails with the above message during writeStream.

*Description of changes:*
The pom.xml was updated to include maven.compiler.release of 8 in its properties.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
