### PR TITLE
README and pom.xml update

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,11 @@ kinesis
   .groupBy("data").count()
   .writeStream
   .format("aws-kinesis")
-  .outputMode("append") 
-  .option("streamName", "sparkSinkTest")
-  .option("endpointUrl", "https://kinesis.us-east-1.amazonaws.com")
+  .outputMode("append")
+  .option("kinesis.region", "us-east-1")
+  .option("kinesis.streamName", "sparkSinkTest")
+  .option("kinesis.endpointUrl", "https://kinesis.us-east-1.amazonaws.com")
+  .option("checkpointLocation", "/path/to/checkpoint")
   .start()
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,42 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java-8-compatible</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-maven-plugin</artifactId>
+            <configuration>
+              <reportsDirectory>${project.build.directory}/unittest-reports</reportsDirectory>
+              <junitxml>.</junitxml>
+              <filereports>WDF UnitTestSuite.txt</filereports>
+              <tagsToExclude>org.apache.spark.sql.connector.kinesis.it.IntegrationTestSuite</tagsToExclude>
+            </configuration>
+            <executions>
+              <execution>
+                <id>test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    
   </profiles>
 
   <distributionManagement>

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/KinesisOptionsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/KinesisOptionsSuite.scala
@@ -215,6 +215,16 @@ class KinesisOptionsSuite extends KinesisTestBase {
     options.stsRoleArn.get shouldBe "assumeRoleTest"
     options.stsSessionName.get shouldBe "sessionNameTest"
   }
+
+  test("sink option uses names as published in README") {
+    ENDPOINT_URL shouldBe "kinesis.endpointUrl"
+    REGION shouldBe "kinesis.region"
+    STREAM_NAME shouldBe "kinesis.streamName"
+    SINK_FLUSH_WAIT_TIME_MILLIS shouldBe "kinesis.sink.flushWaitTimeMs"
+    SINK_RECORD_MAX_BUFFERED_TIME shouldBe "kinesis.sink.recordMaxBufferedTimeMs"
+    SINK_MAX_CONNECTIONS shouldBe "kinesis.sink.maxConnections"
+    SINK_AGGREGATION_ENABLED shouldBe "kinesis.sink.aggregationEnabled"
+  }
 }
 
 object KinesisOptionsSuite {


### PR DESCRIPTION
1. fix README sink example options
2. update pom.xml for building with JDK9+

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
