### PR TITLE
Allow explicit hash key to be passed in so rows can be distributed ac…

### DIFF
--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisWriter.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisWriter.scala
@@ -26,6 +26,7 @@ object KinesisWriter extends Logging {
 
   val DATA_ATTRIBUTE_NAME: String = "data"
   val PARTITION_KEY_ATTRIBUTE_NAME: String = "partitionKey"
+  val EXPLICIT_HASH_KEY_ATTRIBUTE_NAME: String = "explicitHashKey"
 
   override def toString: String = "KinesisWriter"
 


### PR DESCRIPTION
Allow explicit hash key to be passed in so rows can be explicitly distributed across shards.

*Issue #, if available:*
#23 

*Description of changes:*
Allow an `ExplicitHashKey` to be written to Kinesis as part of the payload to easily assign specific rows to specific shards. Within the `selectExpr` you can now add `"CAST(explicitHashKey AS STRING)"`, for example:
```
kinesis
  .selectExpr("CAST(rand() AS STRING) as partitionKey", "CAST(explicitHashKey AS STRING)", "CAST(data AS STRING)").as[(String,String,String)]
  .groupBy("data").count()
  .writeStream
  .format("aws-kinesis")
  .outputMode("append")
  .option("kinesis.region", "us-east-1")
  .option("kinesis.streamName", "sparkSinkTest")
  .option("kinesis.endpointUrl", "https://kinesis.us-east-1.amazonaws.com")
  .option("checkpointLocation", "/path/to/checkpoint")
  .start()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
