### PR TITLE
v1.4.0 release (#31)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 Changelog
 =========
+v1.4.0
+----------------------------
+- plumb through optional recordTtl param to KPL
+
 v1.3.0
 ----------------------------
 - support custom connector credential provider

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Note: Using permanent credentials are not recommended due to security concerns.
 | kinesis.sink.recordMaxBufferedTimeMs | 1000 (milliseconds)              | Specify the maximum buffered time of a record                |
 | kinesis.sink.maxConnections          | 1                                | Specify the maximum connections to Kinesis                   |
 | kinesis.sink.aggregationEnabled      | True                             | Specify if records should be aggregated before sending them to Kinesis |
+| kinesis.sink.recordTtl               | 30000 (milliseconds)             | Records not successfully written to Kinesis within this time are dropped |
 
 
 ## Security

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-streaming-sql-kinesis-connector_2.12</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <packaging>jar</packaging>
   <name>Spark Structured Streaming Kinesis Connector</name>
   <description>Connector to read from and write into Kinesis from Structured Streaming Applications</description>

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/CachedKinesisProducer.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/CachedKinesisProducer.scala
@@ -71,6 +71,11 @@ object CachedKinesisProducer extends Logging {
       KinesisOptions.DEFAULT_SINK_RECORD_MAX_BUFFERED_TIME)
       .toLong
 
+    val recordTTL = kinesisParams.getOrElse(
+      KinesisOptions.SINK_RECORD_TTL,
+      KinesisOptions.DEFAULT_SINK_RECORD_TTL)
+      .toLong
+
     val maxConnections = producerConfiguration.getOrElse(
       KinesisOptions.SINK_MAX_CONNECTIONS.toLowerCase(Locale.ROOT),
       KinesisOptions.DEFAULT_SINK_MAX_CONNECTIONS)
@@ -89,6 +94,7 @@ object CachedKinesisProducer extends Logging {
         com.amazonaws.auth.DefaultAWSCredentialsProviderChain.getInstance
       )
       .setRegion(region)
+      .setRecordTTL(recordTTL)
     )
     logDebug(s"Created a new instance of KinesisProducer for $producerConfiguration.")
     kinesisProducer

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisOptions.scala
@@ -165,12 +165,14 @@ object KinesisOptions {
   val DEFAULT_MAINTENANCE_TASK_INTERVAL_SEC = 100
   
   // Sink options
+  val SINK_RECORD_TTL: String = SINK_PREFIX + "recordTtl"
   val SINK_FLUSH_WAIT_TIME_MILLIS: String = SINK_PREFIX + "flushWaitTimeMs"
   val SINK_RECORD_MAX_BUFFERED_TIME: String = SINK_PREFIX + "recordMaxBufferedTimeMs"
   val SINK_MAX_CONNECTIONS: String = SINK_PREFIX + "maxConnections"
   val SINK_AGGREGATION_ENABLED: String = SINK_PREFIX + "aggregationEnabled"
 
   val DEFAULT_SINK_FLUSH_WAIT_TIME_MILLIS: String = "100"
+  val DEFAULT_SINK_RECORD_TTL: String = "30000"
   val DEFAULT_SINK_RECORD_MAX_BUFFERED_TIME: String = "1000"
   val DEFAULT_SINK_MAX_CONNECTIONS: String = "1"
   val DEFAULT_SINK_AGGREGATION: String = "true"


### PR DESCRIPTION
v1.4.0 release (#31)

- Plumb through optional sink param record TTL to KPL

*Issue #, if available:* #31

*Description of changes:* This allows clients to plumb through a [record ttl](https://javadoc.io/doc/com.amazonaws/amazon-kinesis-producer/latest/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.html#setRecordTtl-long-) value to the KPL. This lets clients override the default 30 second record TTL. The motivation for this is I'd like to specify that I do not want any records dropped by setting a large TTL as recommended by the KPL documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
