### PR TITLE
1.4.1 release - 1/ fix bug in recordTtl casing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 Changelog
 =========
+v1.4.1
+----------------------------
+- fix bug in recordTtl casing (issue #35)
+
+
 v1.4.0
 ----------------------------
 - plumb through optional recordTtl param to KPL (issue #31)

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-streaming-sql-kinesis-connector_2.12</artifactId>
-  <version>1.4.0</version>
+  <version>1.4.1</version>
   <packaging>jar</packaging>
   <name>Spark Structured Streaming Kinesis Connector</name>
   <description>Connector to read from and write into Kinesis from Structured Streaming Applications</description>

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/CachedKinesisProducer.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/CachedKinesisProducer.scala
@@ -72,7 +72,7 @@ object CachedKinesisProducer extends Logging {
       .toLong
 
     val recordTTL = producerConfiguration.getOrElse(
-      KinesisOptions.SINK_RECORD_TTL,
+      KinesisOptions.SINK_RECORD_TTL.toLowerCase(Locale.ROOT),
       KinesisOptions.DEFAULT_SINK_RECORD_TTL)
       .toLong
 


### PR DESCRIPTION
*Issue #, if available:* #35

*Description of changes:*

1.4.1 release (#35)

1/ fix bug in recordTtl casing

Testing: `mvn clean install -DskipTests`, deployed jar, and verified spark param successfully applied

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
