### PR TITLE
Upgrade maven plugin and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,14 @@
 
 
   <properties>
-    <spark.version>3.4.1</spark.version>
+    <spark.version>3.5.5</spark.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <fasterxml.jackson.version>2.14.3</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.18.3</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <aws.sdkv2.version>2.23.9</aws.sdkv2.version>
-    <aws.kpl.version>0.15.8</aws.kpl.version>
+    <aws.sdkv2.version>2.31.11</aws.sdkv2.version>
+    <aws.kpl.version>0.15.12</aws.kpl.version>
+    <log4j.version>2.24.3</log4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -46,6 +47,11 @@
         <version>${aws.sdkv2.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.25.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -118,7 +124,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-aws</artifactId>
-      <version>3.2.4</version>
+      <version>3.4.1</version>
       <scope>test</scope>
     </dependency>
 <!--    <dependency>-->
@@ -129,22 +135,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.12.382</version>
+      <version>1.12.782</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
       <version>${aws.kpl.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.21.7</version>
-      <!--
-         We are being explicit about version here and overriding the
-         spark default of 2.5.0 because KCL appears to have introduced
-         a dependency on protobuf 2.6.1 somewhere between KCL 1.4.0 and 1.6.1.
-       -->
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -169,37 +165,37 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.8.0</version>
+      <version>5.16.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
-      <version>1.16.0</version>
+      <version>1.18.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>3.2.13</version>
+      <version>3.2.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>2.0.6</version>
+      <version>2.0.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.19.0</version>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
-      <version>2.19.0</version>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     
@@ -249,9 +245,87 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.5.0</version>
+          <executions>
+            <execution>
+              <id>enforce-maven</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>3.6.3</version>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.18.0</version>
+          <configuration>
+            <ruleSet>
+              <ignoreVersions>
+                <ignoreVersion>
+                  <type>regex</type>
+                  <version>(.+-SNAPSHOT|.+-M\d)</version>
+                </ignoreVersion>
+                <ignoreVersion>
+                  <type>regex</type>
+                  <version>.+-(alpha|beta).+</version>
+                </ignoreVersion>
+              </ignoreVersions>
+            </ruleSet>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.14.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.4.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.11.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.2.7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.5.3</version>
+        </plugin>
+        <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
-          <version>2.0.0</version>
+          <version>2.2.0</version>
           <executions>
             <execution>
               <id>test</id>
@@ -264,7 +338,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.3.0</version>
+          <version>4.9.5</version>
           <executions>
             <execution>
               <id>compile</id>
@@ -297,37 +371,8 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.0</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>test-jar</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
-          <executions>
-            <execution>
-              <phase>compile</phase>
-              <goals>
-                <goal>compile</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <source>${maven.compiler.source}</source>
-            <target>${maven.compiler.target}</target>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.6.0</version>
           <executions>
             <execution>
               <phase>package</phase>
@@ -486,6 +531,9 @@
     <!-- Enable surefire and scalatest in all children, in one place: -->
     <plugins>
       <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
       </plugin>
@@ -554,7 +602,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-release-plugin</artifactId>
-            <version>2.5.1</version>
+            <version>3.0.1</version>
             <configuration>
               <autoVersionSubmodules>true</autoVersionSubmodules>
             </configuration>

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/PollingRecordBatchPublisherSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/PollingRecordBatchPublisherSuite.scala
@@ -20,7 +20,6 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-
 import org.apache.spark.sql.connector.kinesis.AfterSequenceNumber
 import org.apache.spark.sql.connector.kinesis.KinesisPosition
 import org.apache.spark.sql.connector.kinesis.KinesisPosition.NO_SUB_SEQUENCE_NUMBER
@@ -128,7 +127,7 @@ class PollingRecordBatchPublisherSuite extends KinesisTestBase {
   }
 
   test("recover from ExpiredIteratorException") {
-    val kinesisClient = spy(
+    val kinesisClient = spy[KinesisClientConsumer](
       totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(3, 2, 1, 500)
     )
     val publisher = createPollingRecordPublisher(kinesisClient,

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/client/FakePollingClientConsumerFactory.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/client/FakePollingClientConsumerFactory.scala
@@ -232,10 +232,10 @@ object FakePollingClientConsumerFactory {
   }
 
 
-  private class SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis(numOfRecords: Int,
-                                                                             numOfGetRecordsCalls: Int,
-                                                                             orderOfCallToExpire: Int,
-                                                                             millisBehindLatest: Long)
+  class SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis(numOfRecords: Int,
+                                                                     numOfGetRecordsCalls: Int,
+                                                                     orderOfCallToExpire: Int,
+                                                                     millisBehindLatest: Long)
     extends SingleShardEmittingFixNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls, millisBehindLatest) {
 
     assert(orderOfCallToExpire <= numOfGetRecordsCalls)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update dependencies and maven plugins to the latest compatible versions.
- Enforce maven version to `3.6.3` or above.
- Exclude `SNAPSHOT` and `alpha`/`beta` versions from versions candidates for upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
