### PR TITLE
Add awssdk retries and retries-spi to shaded artifacts to avoid NoClassDefFoundError at runtime.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
       <artifactId>hadoop-aws</artifactId>
       <version>3.4.1</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>bundle</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 <!--    <dependency>-->
 <!--      <groupId>com.amazonaws</groupId>-->
@@ -414,6 +420,8 @@
                     <include>software.amazon.awssdk:profiles:*</include>
                     <include>software.amazon.awssdk:protocol-core:*</include>
                     <include>software.amazon.awssdk:regions:*</include>
+                    <include>software.amazon.awssdk:retries:*</include>
+                    <include>software.amazon.awssdk:retries-spi:*</include>
                     <include>software.amazon.awssdk:third-party-jackson-core:*</include>
                     <include>software.amazon.awssdk:third-party-jackson-dataformat-cbor:*</include>
                     <include>io.dropwizard.metrics:metrics-core:*</include>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
awssdk added retries and retries-spi libraries in version 2.26.x, so after upgrade to awssdk 2.31.x it is necessary to add them to shading.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
