### PR TITLE
Add a Github Action to build and test

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build and Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java:
+          # Re-enable Java 8 testing once EfoRecordBatchPublisherSuite is fixed: #55
+          #- '8'
+          - '11'
+          - '17'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'corretto'
+          cache: maven
+      - name: Build
+        run: mvn -B -DskipTests package
+      - name: Test
+        run: mvn -B test
+      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Update dependency graph
+        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
*Description of changes:*
Build and test each PR for and push to the main branch.

Adapted from the Github Actions template `ci/maven`

> This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
> For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
> 
> This workflow uses actions that are not certified by GitHub.
> They are provided by a third-party and are governed by
> separate terms of service, privacy policy, and support
> documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
