### PR TITLE
Downgrade mockito to 4.11.0 as 5.x requires Java 11 and enable Java 8 in Github action

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -26,8 +26,7 @@ jobs:
     strategy:
       matrix:
         java:
-          # Re-enable Java 8 testing once EfoRecordBatchPublisherSuite is fixed: #55
-          #- '8'
+          - '8'
           - '11'
           - '17'
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.16.1</version>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
*Issue #, if available:*
#55 

*Description of changes:*
Downgrade mockito to 4.11.0 as 5.x requires Java 11 and enable Java 8 in Github action

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
