### PR TITLE
Add a correlator to the dependency snapshot submission

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -42,6 +42,7 @@ jobs:
         run: mvn -B -DskipTests package
       - name: Test
         run: mvn -B test
-      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-      - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v4
+        with:
+          correlator: ${{ github.job }}-${{ matrix.java }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Test
         run: mvn -B test
       - name: Submit Dependency Snapshot
+        if: github.event_name == 'push'
         uses: advanced-security/maven-dependency-submission-action@v4
         with:
           correlator: ${{ github.job }}-${{ matrix.java }}


### PR DESCRIPTION
*Description of changes:*
Update `maven-dependency-submission-action` and add a correlator to support the matrix strategy: https://github.com/advanced-security/maven-dependency-submission-action?tab=readme-ov-file#configuring-for-matrix-based-workflows

Also update that step to only run for pushes, not PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
