### PR TITLE
Exclude Ivy from spark-core & spark-sql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
@@ -106,6 +112,12 @@
       <version>${spark.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
@@ -120,6 +132,12 @@
       <version>${spark.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
*Description of changes:*
We are excluding org.apache.ivy from spark-core & spark-sql dependencies as it is not used by kinesis connector package

*Test*
Ensured build is successful and ran tests locally: 
Run completed in 1 minute, 23 seconds.
Total number of tests run: 88
Suites: completed 38, aborted 0
Tests: succeeded 88, failed 0, canceled 0, ignored 0, pending 0
All tests passed.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
