### PR TITLE
Exclude zookeeper from spark-core and spark-sql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,10 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.ivy</groupId>
           <artifactId>ivy</artifactId>
         </exclusion>
@@ -113,6 +117,10 @@
       <type>test-jar</type>
       <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.ivy</groupId>
           <artifactId>ivy</artifactId>
@@ -137,6 +145,10 @@
       <type>test-jar</type>
       <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.ivy</groupId>
           <artifactId>ivy</artifactId>


### PR DESCRIPTION
*Description of changes:*
We are excluding org.apache.zookeeper from spark-core & spark-sql dependencies as it is not used by kinesis connector package


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
