### PR TITLE
Change groupId from org.apache.spark to com.amazon.emr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.spark</groupId>
+  <groupId>com.amazon.emr</groupId>
   <artifactId>spark-streaming-sql-kinesis-connector_2.12</artifactId>
   <version>1.4.3-SNAPSHOT</version>
   <packaging>jar</packaging>


### PR DESCRIPTION
*Issue #, if available:* 
fixes #58 

*Description of changes:*

Changes groupId from `org.apache.spark` to `com.amazon.emr` in `pom.xml`. This is because `org.apache.spark` groupId should be used only by Apache Spark artifacts.

*Tests*

Ran `mvn clean install` as well as `mvn test`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
