### PR TITLE
Fix reading from closed shards

### DIFF
--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/ShardSyncer.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/ShardSyncer.scala
@@ -263,6 +263,19 @@ object ShardSyncer extends Logging {
             new ShardInfo(shardId, initialPosition.shardPosition(shardId)))
         }
     }
+
+    closedShards(latestShards).foreach {
+      shardId: String =>
+        if (prevShardsList.contains(shardId)) {
+          logDebug(s"Closed shardId ${shardId} already exists")
+        } else {
+          AddShardInfoForAncestors(shardId,
+            latestShards, initialPosition, prevShardsList, newShardsInfoMap, memoizationContext)
+          // Mark closed shards with ShardEnd iterator type to indicate they should not be processed further
+          newShardsInfoMap.put(shardId, new ShardInfo(shardId, new ShardEnd()))
+        }
+    }
+
     logDebug(s"getLatestShardInfo filteredPrevShardsInfo ${filteredPrevShardsInfo}")
     logDebug(s"getLatestShardInfo newShardsInfoMap ${newShardsInfoMap}")
     filteredPrevShardsInfo ++ newShardsInfoMap.values.toSeq


### PR DESCRIPTION
*Issue:* https://github.com/awslabs/spark-sql-kinesis-connector/issues/64

*Description of changes:*
The Kinesis connector handles closed shards differently from open shards. When the ShardSyncer encounters a closed shard, it adds it to the shard map with a ShardEnd iterator type, rather than using the initialPosition like it does for open shards. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
