### PR TITLE
Remove obsolete Java 8 compatibility and fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ cd spark-sql-kinesis-connector
 mvn clean install -DskipTests
 ```
 
-This will create `target/spark-streaming-sql-kinesis-connector_2.12-<kineisis-connector-version>-SNAPSHOT.jar` file which contains the connector and its shaded dependencies. The jar file will also be installed to local maven repository.
+This will create `target/spark-streaming-sql-kinesis-connector_2.13-<kineisis-connector-version>-SNAPSHOT.jar` file which contains the connector and its shaded dependencies. The jar file will also be installed to local maven repository.
 
 After the jar file is installed in local Maven repository, configure your project pom.xml (use Maven as an example):
 
 ```xml
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming-sql-kinesis-connector_2.12</artifactId>
+            <artifactId>spark-streaming-sql-kinesis-connector_2.13</artifactId>
             <version>${kinesis-connector-version}</version>
         </dependency>
 ```
@@ -30,18 +30,6 @@ After the jar file is installed in local Maven repository, configure your projec
 
 
 Current version is tested with Spark 3.2 and above.
-
-### Public jar file
-
-For easier access, there is a public jar file available at S3.  For example, for version 1.0.0, the file path to jar file is `s3://awslabs-code-us-east-1/spark-sql-kinesis-connector/spark-streaming-sql-kinesis-connector_2.12-1.0.0.jar`.
-
-To run with `spark-submit`,  include the jar file as below (version 1.0.0 as an example)
-```
---jars s3://awslabs-code-us-east-1/spark-sql-kinesis-connector/spark-streaming-sql-kinesis-connector_2.12-1.0.0.jar
-```
-The jar file can also be downloaded at `https://awslabs-code-us-east-1.s3.amazonaws.com/spark-sql-kinesis-connector/spark-streaming-sql-kinesis-connector_2.12-1.0.0.jar`
-
-Change the jar file name based on version, e.g. version 1.1.0 is spark-streaming-sql-kinesis-connector_2.12-1.1.0.jar
 
 ## How to use it
 

--- a/pom.xml
+++ b/pom.xml
@@ -679,41 +679,6 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>java-8-compatible</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>net.alchim31.maven</groupId>
-            <artifactId>scala-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest-maven-plugin</artifactId>
-            <configuration>
-              <reportsDirectory>${project.build.directory}/unittest-reports</reportsDirectory>
-              <junitxml>.</junitxml>
-              <filereports>WDF UnitTestSuite.txt</filereports>
-              <tagsToExclude>org.apache.spark.sql.connector.kinesis.it.IntegrationTestSuite</tagsToExclude>
-            </configuration>
-            <executions>
-              <execution>
-                <id>test</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     
   </profiles>
 
@@ -731,9 +696,9 @@
   <reporting>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.14</version>
       </plugin>
     </plugins>
   </reporting>

--- a/src/main/java/org/apache/spark/sql/connector/kinesis/retrieval/AggregatorUtil.java
+++ b/src/main/java/org/apache/spark/sql/connector/kinesis/retrieval/AggregatorUtil.java
@@ -201,7 +201,7 @@ public class AggregatorUtil {
               }
               sb.append("Sequence number: ").append(r.sequenceNumber()).append("\n")
                   .append("Raw data: ")
-                  .append(javax.xml.bind.DatatypeConverter.printBase64Binary(messageData)).append("\n");
+                  .append(java.util.Base64.getEncoder().encodeToString(messageData)).append("\n");
               log.error(sb.toString(), e);
             }
           } catch (InvalidProtocolBufferException e) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Removed the `java-8-compatible` Maven profile (obsolete since project targets Java 17)
- Replaced deprecated `javax.xml.bind.DatatypeConverter.printBase64Binary()` with `java.util.Base64` in `AggregatorUtil.java`
- Replaced obsolete `cobertura-maven-plugin` (Java 8 only, abandoned since 2015) with `jacoco-maven-plugin:0.8.14` in reporting section
- Updated README to remove broken public S3 jar download instructions

*Build and Testing*
`mvn clean install`: was a success

```
Run completed in 1 minute, 22 seconds.
Total number of tests run: 94
Suites: completed 39, aborted 0
Tests: succeeded 94, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  38.904 s
[INFO] Finished at: 2026-05-08T12:28:28-07:00
[INFO] ------------------------------------------------------------------------
```

*Jacoco Plugin testing*
Made sure the Jacoco plugin works locally by running - `mvn org.jacoco:jacoco-maven-plugin:0.8.14:prepare-agent test org.jacoco:jacoco-maven-plugin:0.8.14:report`

This generated the below website:

<img width="1265" height="365" alt="Image" src="https://github.com/user-attachments/assets/8127841e-05d9-41b9-81e8-1fb5c540eedf" />


<br>

Co-authored-by: Shrirang Mhalgi <srmhalgi@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
