### PR TITLE
Update SerializedOffset and MemoryStream imports for Spark 4.1 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 
   <properties>
-    <spark.version>4.0.1</spark.version>
+    <spark.version>4.1.0</spark.version>
     <scala.binary.version>2.13</scala.binary.version>
     <fasterxml.jackson.version>2.18.3</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2SourceOffset.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2SourceOffset.scala
@@ -24,7 +24,7 @@ import org.json4s.NoTypeHints
 import org.json4s.jackson.Serialization
 
 import org.apache.spark.sql.connector.read.streaming.Offset
-import org.apache.spark.sql.execution.streaming.SerializedOffset
+import org.apache.spark.sql.execution.streaming.runtime.SerializedOffset
 
 case class KinesisV2SourceOffset(shardsToOffsets: ShardOffsets) extends Offset {
   override def json: String = {

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/it/KinesisSinkItSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/it/KinesisSinkItSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.connector.kinesis.KinesisOptions.EFO_CONSUMER_TYPE
 import org.apache.spark.sql.connector.kinesis.KinesisOptions.HDFS_COMMITTER_TYPE
 import org.apache.spark.sql.connector.kinesis.KinesisV2TableProvider.AWS_KINESIS_SHORT_NAME
 import org.apache.spark.sql.connector.kinesis.TrimHorizon
-import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.streaming.DataStreamWriter
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.streaming.StreamingQuery


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Moving `main` to track Apache Spark version `4.1.0`. Also, Spark 4.1 changed the import path for `SerializedOffset` and `MemoryStream`, which need to be adjusted. 

*Testing*

After bumping spark.version to 4.1.0, got `not found: type SerializedOffset` and cascading `type mismatch;
 found   : org.apache.spark.sql.connector.kinesis.ShardOffsets`:

```
[ERROR] /Volumes/workplace/spark-sql-kinesis-connector/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2SourceOffset.scala:68: not found: type SerializedOffset
[WARNING] /Volumes/workplace/spark-sql-kinesis-connector/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisModel.scala:161: Implicit definition should have explicit type (inferred org.json4s.Formats{val dateFormat: org.json4s.DateFormat; val typeHints: org.json4s.TypeHints}) [quickfixable]
[ERROR] /Volumes/workplace/spark-sql-kinesis-connector/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2MicrobatchStream.scala:232: type mismatch;
 found   : org.apache.spark.sql.connector.kinesis.ShardOffsets
 required: String
....
[WARNING] 6 warnings found
[ERROR] 9 errors found
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.706 s
[INFO] Finished at: 2026-05-18T12:36:17-07:00
[INFO] ------------------------------------------------------------------------
```
followed by the same for `MemoryStream`.

After import changes:

`mvn clean install`

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:54 min
[INFO] Finished at: 2026-05-18T13:20:03-07:00
[INFO] ------------------------------------------------------------------------
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
