### PR TITLE
Propagate failOnDataLoss configuration correctly through Kinesis consumer clients

### DIFF
--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2MicrobatchStream.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2MicrobatchStream.scala
@@ -111,7 +111,9 @@ class KinesisV2MicrobatchStream (
     val shardIterator = kinesisClient.getShardIterator(
       shardInfo.shardId,
       shardInfo.iteratorType,
-      shardInfo.iteratorPosition)
+      shardInfo.iteratorPosition,
+      options.failOnDataLoss
+    )
 
     def getRecordsResponseInfo(shardIterator: String): (Int, Long, String) = {
       val records = kinesisClient.getKinesisRecords(shardIterator, 1)

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/client/KinesisClientConsumer.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/client/KinesisClientConsumer.scala
@@ -47,7 +47,7 @@ trait KinesisClientConsumer {
   def getShardIterator(shardId: String,
                         iteratorType: String,
                         iteratorPosition: String,
-                        failOnDataLoss: Boolean = false): String
+                        failOnDataLoss: Boolean): String
 
   def getKinesisRecords(shardIterator: String, limit: Int): GetRecordsResponse
 

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/client/KinesisClientConsumerImpl.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/client/KinesisClientConsumerImpl.scala
@@ -286,7 +286,7 @@ case class KinesisClientConsumerImpl(
   override def getShardIterator(shardId: String,
                        iteratorType: String,
                        iteratorPosition: String,
-                       failOnDataLoss: Boolean = true): String = {
+                       failOnDataLoss: Boolean = options.failOnDataLoss): String = {
 
     val getShardIteratorRequestBuilder = GetShardIteratorRequest.builder()
       .shardId(shardId)

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/polling/PollingRecordBatchPublisher.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/polling/PollingRecordBatchPublisher.scala
@@ -50,7 +50,7 @@ class PollingRecordBatchPublisher(
   // visible for test only
   var nextStartingPosition: KinesisPosition = initialStartingPosition
 
-  private var nextShardItr: String = getShardIterator
+  private var nextShardItr: String = getShardIterator()
   private var processingStartTimeNanos = System.nanoTime
 
   private var lastRecordBatchSize = 0
@@ -105,7 +105,7 @@ class PollingRecordBatchPublisher(
       catch {
         case eiEx: ExpiredIteratorException =>
           logError(s"Encountered an unexpected expired iterator ${nextShardItr} for shard ${streamShard}. refreshing the iterator ...", eiEx)
-          nextShardItr = getShardIterator
+          nextShardItr = getShardIterator(kinesisOptions.failOnDataLoss)
           // sleep for the fetch interval before the next getRecords attempt with the
           // refreshed iterator
           if (fetchIntervalMillis != 0) Thread.sleep(fetchIntervalMillis)
@@ -114,7 +114,7 @@ class PollingRecordBatchPublisher(
     getRecordsResult
   }
 
-  private def getShardIterator = {
+  private def getShardIterator(failOnDataLoss: Boolean = kinesisOptions.failOnDataLoss) = {
 
     val iteratorType = if ( nextStartingPosition.iteratorType == AfterSequenceNumber.iteratorType
       && nextStartingPosition.subSequenceNumber != NO_SUB_SEQUENCE_NUMBER
@@ -127,7 +127,9 @@ class PollingRecordBatchPublisher(
     kinesisConsumer.getShardIterator(
       streamShard.shard.shardId(),
       iteratorType,
-      nextStartingPosition.iteratorPosition)
+      nextStartingPosition.iteratorPosition,
+      failOnDataLoss
+    )
   }
 
   private def adjustToFetchInterval(processingStartTimeNanos: Long, processingEndTimeNanos: Long) = {

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/client/KinesisClientConsumerGetShardIteratorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/client/KinesisClientConsumerGetShardIteratorSuite.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connector.kinesis.client
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse
+
+import org.apache.spark.sql.connector.kinesis.KinesisOptions
+import org.apache.spark.sql.connector.kinesis.KinesisOptions._
+import org.apache.spark.sql.connector.kinesis.KinesisPosition
+import org.apache.spark.sql.connector.kinesis.KinesisPosition.NO_SUB_SEQUENCE_NUMBER
+import org.apache.spark.sql.connector.kinesis.KinesisTestBase
+import org.apache.spark.sql.connector.kinesis.Latest
+import org.apache.spark.sql.connector.kinesis.TestConsumer
+import org.apache.spark.sql.connector.kinesis.retrieval.StreamShard
+import org.apache.spark.sql.connector.kinesis.retrieval.client.FakeKinesisClientConsumerAdapter
+import org.apache.spark.sql.connector.kinesis.retrieval.polling.PollingRecordBatchPublisher
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class KinesisClientConsumerGetShardIteratorSuite extends KinesisTestBase {
+
+  test("KinesisOptions defaults failOnDataLoss to false") {
+    DEFAULT_KINESIS_OPTIONS.failOnDataLoss shouldBe false
+  }
+
+  test("KinesisOptions parses explicit failOnDataLoss true") {
+    val options = KinesisOptions(new CaseInsensitiveStringMap(Map(
+      REGION -> DEFAULT_TEST_REGION,
+      ENDPOINT_URL -> DEFAULT_TEST_ENDPOINT_URL,
+      CONSUMER_TYPE -> POLLING_CONSUMER_TYPE,
+      STREAM_NAME -> DEFAULT_TEST_STEAM_NAME,
+      FAIL_ON_DATA_LOSS -> "true"
+    ).asJava))
+    options.failOnDataLoss shouldBe true
+  }
+
+  test("PollingRecordBatchPublisher passes failOnDataLoss=false to getShardIterator on init") {
+    var capturedFailOnDataLoss: Option[Boolean] = None
+
+    val client = new FakeKinesisClientConsumerAdapter {
+      override def getShardIterator(shardId: String,
+                                    iteratorType: String,
+                                    iteratorPosition: String,
+                                    failOnDataLoss: Boolean): String = {
+        capturedFailOnDataLoss = Some(failOnDataLoss)
+        "iter-0"
+      }
+
+      override def getKinesisRecords(shardIterator: String, limit: Int): GetRecordsResponse = {
+        GetRecordsResponse.builder().millisBehindLatest(0L).build()
+      }
+    }
+
+    val publisher = new PollingRecordBatchPublisher(
+      KinesisPosition.make(Latest.iteratorType, DEFAULT_TIMESTAMP, NO_SUB_SEQUENCE_NUMBER, isLast = true),
+      StreamShard(DEFAULT_TEST_STEAM_NAME, DEFAULT_TEST_SHARD),
+      client,
+      DEFAULT_KINESIS_OPTIONS,
+      true
+    )
+
+    val consumer = new TestConsumer(publisher.initialStartingPosition)
+    publisher.runProcessLoop(consumer)
+
+    capturedFailOnDataLoss shouldBe Some(false)
+  }
+
+  for (failOnDataLoss <- Seq(false, true)) {
+    test(s"PollingRecordBatchPublisher passes failOnDataLoss=$failOnDataLoss on expired iterator refresh") {
+      var capturedFailOnDataLoss: Option[Boolean] = None
+      var callCount = 0
+
+      val options = if (failOnDataLoss) {
+        KinesisOptions(new CaseInsensitiveStringMap(Map(
+          REGION -> DEFAULT_TEST_REGION,
+          ENDPOINT_URL -> DEFAULT_TEST_ENDPOINT_URL,
+          CONSUMER_TYPE -> POLLING_CONSUMER_TYPE,
+          STREAM_NAME -> DEFAULT_TEST_STEAM_NAME,
+          FAIL_ON_DATA_LOSS -> "true"
+        ).asJava))
+      } else DEFAULT_KINESIS_OPTIONS
+
+      val client = new FakeKinesisClientConsumerAdapter {
+        override def getShardIterator(shardId: String,
+                                      iteratorType: String,
+                                      iteratorPosition: String,
+                                      failOnDataLoss: Boolean): String = {
+          capturedFailOnDataLoss = Some(failOnDataLoss)
+          "iter-0"
+        }
+
+        override def getKinesisRecords(shardIterator: String, limit: Int): GetRecordsResponse = {
+          callCount += 1
+          if (callCount == 1) {
+            throw software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException
+              .builder().message("Expired").build()
+          }
+          GetRecordsResponse.builder().millisBehindLatest(0L).build()
+        }
+      }
+
+      val publisher = new PollingRecordBatchPublisher(
+        KinesisPosition.make(Latest.iteratorType, DEFAULT_TIMESTAMP, NO_SUB_SEQUENCE_NUMBER, isLast = true),
+        StreamShard(DEFAULT_TEST_STEAM_NAME, DEFAULT_TEST_SHARD),
+        client,
+        options,
+        true
+      )
+
+      val consumer = new TestConsumer(publisher.initialStartingPosition)
+      publisher.runProcessLoop(consumer)
+
+      capturedFailOnDataLoss shouldBe Some(failOnDataLoss)
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/PollingRecordBatchPublisherSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/PollingRecordBatchPublisherSuite.scala
@@ -146,7 +146,7 @@ class PollingRecordBatchPublisherSuite extends KinesisTestBase {
 
     // Get shard iterator is called twice, once during first run, secondly to refresh expired
     // iterator
-    verify(kinesisClient, times(2)).getShardIterator("", "", "")
+    verify(kinesisClient, times(2)).getShardIterator("shardId-000000000000", "LATEST", "", false)
 
     consumer.getRecordBatches.size shouldBe 1
     consumer.getRecordBatches.get(0).userRecords.size shouldBe 2

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/client/FakeKinesisClientConsumerAdapter.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/client/FakeKinesisClientConsumerAdapter.scala
@@ -63,7 +63,7 @@ class FakeKinesisClientConsumerAdapter extends KinesisClientConsumer {
   override def getShardIterator(shardId: String,
                                 iteratorType: String,
                                 iteratorPosition: String,
-                                failOnDataLoss: Boolean = true): String = {
+                                failOnDataLoss: Boolean): String = {
     throw new UnsupportedOperationException("This method is not implemented.")
   }
 

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/client/FakePollingClientConsumerFactory.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/client/FakePollingClientConsumerFactory.scala
@@ -38,18 +38,22 @@ import software.amazon.awssdk.services.kinesis.model.Record
 import software.amazon.awssdk.services.kinesis.model.SequenceNumberRange
 import software.amazon.awssdk.services.kinesis.model.Shard
 
+import org.apache.spark.sql.connector.kinesis.KinesisOptions
 import org.apache.spark.sql.connector.kinesis.client.KinesisClientConsumer
 import org.apache.spark.sql.connector.kinesis.retrieval.StreamShard
 
 object FakePollingClientConsumerFactory {
 
-  def noShardsFoundForRequestedStreams: KinesisClientConsumer = new FakeKinesisClientConsumerAdapter() {
+  def noShardsFoundForRequestedStreams: KinesisClientConsumer = noShardsFoundForRequestedStreams(None)
+
+  def noShardsFoundForRequestedStreams(kinesisOptions: Option[KinesisOptions] = None): KinesisClientConsumer
+  = new FakeKinesisClientConsumerAdapter() {
     override def getShards: Seq[Shard] = Seq.empty[Shard]
 
     override def getShardIterator(shardId: String,
                                   iteratorType: String,
                                   iteratorPosition: String,
-                                  failOnDataLoss: Boolean = true): String = null
+                                  failOnDataLoss: Boolean = kinesisOptions.get.failOnDataLoss): String = null
 
     override def getKinesisRecords(shardIterator: String, limit: Int): GetRecordsResponse = null
   }
@@ -69,6 +73,16 @@ object FakePollingClientConsumerFactory {
       millisBehindLatest)
   }
 
+  def totalNumOfRecordsAfterNumOfGetRecordsCalls(numOfRecords: Int,
+                                                 numOfGetRecordsCalls: Int,
+                                                 millisBehindLatest: Long,
+                                                 kinesisOptions: KinesisOptions): KinesisClientConsumer = {
+    new SingleShardEmittingFixNumOfRecordsKinesis(numOfRecords,
+      numOfGetRecordsCalls,
+      millisBehindLatest,
+      kinesisOptions)
+  }
+
   def totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(numOfRecords: Int,
                                                                               numOfGetRecordsCall: Int,
                                                                               orderOfCallToExpire: Int,
@@ -79,12 +93,34 @@ object FakePollingClientConsumerFactory {
       millisBehindLatest)
   }
 
+  def totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(numOfRecords: Int,
+                                                                              numOfGetRecordsCall: Int,
+                                                                              orderOfCallToExpire: Int,
+                                                                              millisBehindLatest: Long,
+                                                                              kinesisOptions: Option[KinesisOptions] = None)
+  : KinesisClientConsumer = {
+    new SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis(numOfRecords,
+      numOfGetRecordsCall,
+      orderOfCallToExpire,
+      millisBehindLatest,
+      kinesisOptions.get)
+  }
+
   def aggregatedRecords(numOfAggregatedRecords: Int, numOfChildRecords: Int, numOfGetRecordsCalls: Int): KinesisClientConsumer = {
     new SingleShardEmittingAggregatedRecordsKinesis(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls)
   }
 
+  def aggregatedRecords(numOfAggregatedRecords: Int, numOfChildRecords: Int, numOfGetRecordsCalls: Int, kinesisOptions: KinesisOptions)
+  : KinesisClientConsumer = {
+    new SingleShardEmittingAggregatedRecordsKinesis(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls, kinesisOptions)
+  }
+
   def blockingQueueGetRecords(streamName: String, shardQueues: Seq[BlockingQueue[String]]): KinesisClientConsumer = {
     new BlockingQueueKinesis(streamName, shardQueues)
+  }
+
+  def blockingQueueGetRecords(streamName: String, shardQueues: Seq[BlockingQueue[String]], kinesisOptions: KinesisOptions): KinesisClientConsumer = {
+    new BlockingQueueKinesis(streamName, shardQueues, kinesisOptions)
   }
 
   def generateFromShardOrder(order: Int): String = "shardId-%012d".format(order)
@@ -115,14 +151,15 @@ object FakePollingClientConsumerFactory {
     StreamShard(streamName, shard)
   }
 
-  class SingleShardEmittingZeroRecords (var remainingIterators: Int) extends FakeKinesisClientConsumerAdapter {
+  class SingleShardEmittingZeroRecords (var remainingIterators: Int)
+    extends FakeKinesisClientConsumerAdapter {
 
     override def getShards: Seq[Shard] = null
 
     override def getShardIterator(shardId: String,
                                   iteratorType: String,
                                   iteratorPosition: String,
-                                  failOnDataLoss: Boolean = true): String = {
+                                  failOnDataLoss: Boolean): String = {
       val t = remainingIterators.toString
       remainingIterators -= 1
       t
@@ -157,13 +194,13 @@ object FakePollingClientConsumerFactory {
     }
 
     override def getShards: Seq[Shard] = {
-        dummyShards.map(_.shard)
+        dummyShards.map(_.shard).toSeq
       }
 
     override def getShardIterator(shardId: String,
                                   iteratorType: String,
                                   iteratorPosition: String,
-                                  failOnDataLoss: Boolean = true): String = null
+                                  failOnDataLoss: Boolean): String = null
 
 
     override def getKinesisRecords(shardIterator: String, limit: Int): GetRecordsResponse = null
@@ -180,13 +217,19 @@ object FakePollingClientConsumerFactory {
           .sequenceNumber(i.toString)
           .build
       }
-      batch
+      batch.toSeq
     }
   }
 
   class SingleShardEmittingFixNumOfRecordsKinesis(totalNumOfRecords: Int,
                                                   totalNumOfGetRecordsCalls: Int,
-                                                  millisBehindLatest: Long) extends FakeKinesisClientConsumerAdapter {
+                                                  millisBehindLatest: Long,
+                                                  kinesisOptions: Option[KinesisOptions] = None) extends FakeKinesisClientConsumerAdapter {
+
+    def this(totalNumOfRecords: Int, totalNumOfGetRecordsCalls: Int, millisBehindLatest: Long) =
+      this(totalNumOfRecords, totalNumOfGetRecordsCalls, millisBehindLatest, None)
+    def this(totalNumOfRecords: Int, totalNumOfGetRecordsCalls: Int, millisBehindLatest: Long, kinesisOptions: KinesisOptions) =
+      this(totalNumOfRecords, totalNumOfGetRecordsCalls, millisBehindLatest, Some(kinesisOptions))
 
     // initialize the record batches that we will be fetched
     val shardItrToRecordBatch = mutable.Map.empty[String, Seq[Record]]
@@ -223,7 +266,7 @@ object FakePollingClientConsumerFactory {
     override def getShardIterator(shardId: String,
                                   iteratorType: String,
                                   iteratorPosition: String,
-                                  failOnDataLoss: Boolean = true): String = {
+                                  failOnDataLoss: Boolean = kinesisOptions.get.failOnDataLoss): String = {
       // Should be called only once. Simply return the iterator of the first batch of records
       "0"
     }
@@ -235,8 +278,14 @@ object FakePollingClientConsumerFactory {
   class SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis(numOfRecords: Int,
                                                                      numOfGetRecordsCalls: Int,
                                                                      orderOfCallToExpire: Int,
-                                                                     millisBehindLatest: Long)
-    extends SingleShardEmittingFixNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls, millisBehindLatest) {
+                                                                     millisBehindLatest: Long,
+                                                                     kinesisOptions: Option[KinesisOptions] = None)
+    extends SingleShardEmittingFixNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls, millisBehindLatest, kinesisOptions) {
+
+    def this(numOfRecords: Int, numOfGetRecordsCalls: Int, orderOfCallToExpire: Int, millisBehindLatest: Long) =
+      this(numOfRecords, numOfGetRecordsCalls, orderOfCallToExpire, millisBehindLatest, None)
+    def this(numOfRecords: Int, numOfGetRecordsCalls: Int, orderOfCallToExpire: Int, millisBehindLatest: Long, kinesisOptions: KinesisOptions) =
+      this(numOfRecords, numOfGetRecordsCalls, orderOfCallToExpire, millisBehindLatest, Some(kinesisOptions))
 
     assert(orderOfCallToExpire <= numOfGetRecordsCalls)
 
@@ -266,7 +315,7 @@ object FakePollingClientConsumerFactory {
     override def getShardIterator(shardId: String,
                                   iteratorType: String,
                                   iteratorPosition: String,
-                                  failOnDataLoss: Boolean = true): String = if (!expiredOnceAlready) {
+                                  failOnDataLoss: Boolean): String = if (!expiredOnceAlready) {
       // for the first call, just return the iterator of the first batch of records
       "0"
     }
@@ -315,22 +364,35 @@ object FakePollingClientConsumerFactory {
                 .sequenceNumber(sequenceNumber.getAndAdd(numOfChildRecords).toString)
                 .build
       }
-      recordBatch
+      recordBatch.toSeq
     }
 
   }
 
   private class SingleShardEmittingAggregatedRecordsKinesis(numOfAggregatedRecords: Int,
                                                             numOfChildRecords: Int,
-                                                            numOfGetRecordsCalls: Int)
+                                                            numOfGetRecordsCalls: Int,
+                                                            kinesisOptions: Option[KinesisOptions] = None)
     extends SingleShardEmittingKinesis(
-      SingleShardEmittingAggregatedRecordsKinesis.initShardItrToRecordBatch(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls)
-    ) {}
+      SingleShardEmittingAggregatedRecordsKinesis.initShardItrToRecordBatch(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls),
+      0L,
+      kinesisOptions
+    ) {
+
+    def this(numOfAggregatedRecords: Int, numOfChildRecords: Int, numOfGetRecordsCalls: Int) =
+      this(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls, None)
+    def this(numOfAggregatedRecords: Int, numOfChildRecords: Int, numOfGetRecordsCalls: Int, kinesisOptions: KinesisOptions) =
+      this(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls, Some(kinesisOptions))
+  }
 
   abstract class SingleShardEmittingKinesis (shardItrToRecordBatch: Map[String, Seq[Record]],
-                                             millisBehindLatest: Long) extends FakeKinesisClientConsumerAdapter {
+                                             millisBehindLatest: Long,
+                                             kinesisOptions: Option[KinesisOptions] = None) extends FakeKinesisClientConsumerAdapter {
     def this(shardItrToRecordBatch: Map[String, Seq[Record]]) {
-      this(shardItrToRecordBatch, 0L)
+      this(shardItrToRecordBatch, 0L, None)
+    }
+    def this(shardItrToRecordBatch: Map[String, Seq[Record]], kinesisOptions: KinesisOptions) {
+      this(shardItrToRecordBatch, 0L, Some(kinesisOptions))
     }
 
     override def getKinesisRecords(shardIterator: String, limit: Int): GetRecordsResponse = {
@@ -351,7 +413,7 @@ object FakePollingClientConsumerFactory {
     override def getShardIterator(shardId: String,
                                   iteratorType: String,
                                   iteratorPosition: String,
-                                  failOnDataLoss: Boolean = true): String = {
+                                  failOnDataLoss: Boolean): String = {
       // Should be called only once. Simply return the iterator of the first batch of records
       "0"
     }
@@ -364,7 +426,12 @@ object FakePollingClientConsumerFactory {
     def getShardIterator(streamName: String, shardId: String): String = s"${streamName}-${shardId}"
   }
 
-  class BlockingQueueKinesis(streamName: String, shardQueues: Seq[BlockingQueue[String]]) extends FakeKinesisClientConsumerAdapter {
+  class BlockingQueueKinesis(streamName: String, shardQueues: Seq[BlockingQueue[String]], kinesisOptions: Option[KinesisOptions] = None)
+    extends FakeKinesisClientConsumerAdapter {
+
+    def this(streamName: String, shardQueues: Seq[BlockingQueue[String]]) = this(streamName, shardQueues, None)
+    def this(streamName: String, shardQueues: Seq[BlockingQueue[String]], kinesisOptions: KinesisOptions)
+      = this(streamName, shardQueues, Some(kinesisOptions))
 
     private val listOfShards = mutable.ArrayBuffer.empty[StreamShard]
     private val shardIteratorToQueueMap = mutable.Map.empty[String, BlockingQueue[String]]
@@ -392,7 +459,7 @@ object FakePollingClientConsumerFactory {
     override def getShardIterator(shardId: String,
                                   iteratorType: String,
                                   iteratorPosition: String,
-                                  failOnDataLoss: Boolean = true): String = {
+                                  failOnDataLoss: Boolean): String = {
       BlockingQueueKinesis.getShardIterator(streamName, shardId)
     }
 
@@ -418,7 +485,7 @@ object FakePollingClientConsumerFactory {
     }
 
     GetRecordsResponse.builder()
-      .records(records: _*)
+      .records(records.toSeq: _*)
       .millisBehindLatest(0L)
       .nextShardIterator(nextShardIterator)
       .build
@@ -427,7 +494,7 @@ object FakePollingClientConsumerFactory {
     override def getShards: Seq[Shard] = {
       listOfShards.map { streamShards =>
         streamShards.shard
-      }
+      }.toSeq
     }
   }
 }


### PR DESCRIPTION
This is a (not clean) cherry-pick of #81 , which was pushed to the main branch previously. Moving it onto branch-1.4.3.

*Description of changes:*
Honors and propagates what customer configures for `failOnDataLoss` in getShardIterator for all Kinesis consumers and clients. This is meant to limit data loss upon shard failure.

`mvn clean install:`
```
Run completed in 1 minute, 17 seconds.
Total number of tests run: 94
Suites: completed 39, aborted 0
Tests: succeeded 94, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

Local Testing:
Ran EMR clusters separately with the `failOnDataLoss` defaulted to false on the new version of code and true on the mainline version of code.

Scala test file for testing `failOnDataLoss=true`. Changed all `true` to `false` for the comparison case:
```
import org.apache.spark.sql.SparkSession
import org.apache.spark.sql.streaming.Trigger

val streamName = "reshard-test"
val region = "us-east-1"
val checkpointDir = "s3://<REDACTED>/checkpoint/reshard-test-true"
val failOnDataLoss = "true"
val outputPath = "s3://<REDACTED>/output/reshard-test-true"

val query = spark.readStream
  .format("kinesis")
  .option("kinesis.streamName", streamName)
  .option("kinesis.region", region)
  .option("kinesis.startingPosition", "LATEST")
  .option("kinesis.failOnDataLoss", failOnDataLoss)
  .option("kinesis.describeShardInterval", "0")
  .load()
  .selectExpr("CAST(data AS STRING) as value", "shardId", "approximateArrivalTimestamp")
  .writeStream
  .format("json")
  .option("path", outputPath)
  .option("checkpointLocation", checkpointDir)
  .trigger(Trigger.ProcessingTime("10 seconds"))
  .start()

query.awaitTermination()
```

Shell commands:
```
    for i in $(seq 1 20); do
      aws kinesis put-record --stream-name reshard-test --partition-key key-$i \
      --data $(echo -n "message-$i" | base64) --region us-east-1
    done

    aws kinesis update-shard-count --stream-name reshard-test --target-shard-count 2 \
      --scaling-type UNIFORM_SCALING --region us-east-1

    for i in $(seq 21 40); do
      aws kinesis put-record --stream-name reshard-test --partition-key key-$i \
      --data $(echo -n "message-$i" | base64) --region us-east-1
    done
```

Upon shutting down the data stream and restarting the job, the cluster tries to pick up from where it left off (reading from the checkpoint) and failed immediately with the previous default. This behavior did not happen after the change with the specified `failOnDataLoss=true`


Print statements also confirm that the variables are being passed to proper locations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

