### PR TITLE
Fix credential file reload: use ProfileFileSupplier.defaultSupplier() and bump AWS SDK version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <fasterxml.jackson.version>2.18.3</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <aws.sdkv2.version>2.31.11</aws.sdkv2.version>
+    <aws.sdkv2.version>2.44.5</aws.sdkv2.version>
     <aws.kpl.version>0.15.12</aws.kpl.version>
     <log4j.version>2.24.3</log4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/ConnectorAwsCredentialsProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/ConnectorAwsCredentialsProvider.scala
@@ -31,6 +31,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.profiles.ProfileFileSupplier
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
@@ -76,6 +77,7 @@ case class BasicAwsSessionCredentials(
 case class RetryableDefaultCredentialsProvider() extends AwsCredentialsProvider with Closeable with Logging {
   private val provider = DefaultCredentialsProvider.builder()
     .asyncCredentialUpdateEnabled(true)
+    .profileFile(ProfileFileSupplier.defaultSupplier())
     .build()
   
   private val MAX_ATTEMPT = 15


### PR DESCRIPTION
This commit is an (almost clean) cherry-pick of #86, which was originally pushed to the main branch. Tested with 7.13.

*Issue #, if available:*
https://github.com/awslabs/spark-sql-kinesis-connector/issues/85

*Description of changes:*

The `RetryableDefaultCredentialsProvider` never re-reads the credentials file after startup. The SDK v2's `ProfileCredentialsProvider` loads the file once and caches it even when a refresh service writes new credentials to disk
([aws-sdk-java-v2#1754](https://github.com/aws/aws-sdk-java-v2/issues/1754)).

This fix passes `ProfileFileSupplier.defaultSupplier()` to the `DefaultCredentialsProvider` builder, which is the SDK's documented [mechanism](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-profiles.html#profile-reloading) for enabling credential file reload. It handles both `AWS_SHARED_CREDENTIALS_FILE` and `~/.aws/credentials` paths.

Also bumps `aws-sdk-java-v2` from `2.31.11` to `2.44.5` to include the fix for a known NPE in `defaultSupplier()` when credential files don't exist
([aws-sdk-java-v2#6150](https://github.com/aws/aws-sdk-java-v2/pull/6150)).

*Testing:*

```
mvn clean install
```
`BUILD SUCCESS`, all unit tests pass.

Integration testing on EMR Spark 8.0.0 (EC2):

- Custom credentials path (`AWS_SHARED_CREDENTIALS_FILE=/home/hadoop/.aws/credentials-test`): 15-minute STS credentials refreshed to file every 5 minutes. Patched jar runs through multiple credential rotations without error.
- Default credentials path (`~/.aws/credentials`): Same setup, no env var. Runs through multiple rotations without error.
- No credentials file (IMDS only): Removed all credential files and unset env var. Patched jar works correctly using instance profile credentials, no regression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
