### PR TITLE
Fix EFO infinite loop when starting at LATEST with idle shards

### DIFF
--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2MicrobatchStream.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2MicrobatchStream.scala
@@ -131,8 +131,9 @@ class KinesisV2MicrobatchStream (
       millisBehindLatest = millisBehindLatestCatchUp
       nextShardIterator = nextShardIteratorCatchUp
     }
-    // Return true if we can get back a record. Or if we have not reached the end of the stream
-    val result = (recordsSize > 0 || millisBehindLatest > 0)
+    // Return true if we can get back a record. Or if we have not reached the end of the stream.
+    val result = (recordsSize > 0 || millisBehindLatest > 0
+      || shardInfo.iteratorType == org.apache.spark.sql.connector.kinesis.AtTimeStamp.iteratorType)
     logInfo(s"hasNewData result ${result} for shardId ${shardInfo.shardId}")
     result
   }

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2PartitionReader.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/KinesisV2PartitionReader.scala
@@ -346,6 +346,14 @@ class KinesisV2PartitionReader (schema: StructType,
               lastReadSequenceNumber.subSequenceNumber,
               lastReadSequenceNumber.isLast))
       }
+      else if (recordBatchPublisher.currentStartingPosition != recordBatchPublisher.initialStartingPosition) {
+        logInfo(s"No user records but publisher advanced for ${sourcePartition.startShardInfo}")
+        new ShardInfo(sourcePartition.startShardInfo.shardId, recordBatchPublisher.currentStartingPosition)
+      }
+      else if (sourcePartition.startShardInfo.iteratorType == AtTimeStamp.iteratorType) {
+        logInfo(s"Converting stuck AT_TIMESTAMP to LATEST for ${sourcePartition.startShardInfo}")
+        new ShardInfo(sourcePartition.startShardInfo.shardId, new Latest())
+      }
       else {
         logInfo(s"No Records were processed in this batch for ${sourcePartition.startShardInfo}")
         sourcePartition.startShardInfo

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/RecordBatchPublisher.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/RecordBatchPublisher.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.connector.kinesis.retrieval.SequenceNumber.SENTINEL_
 trait RecordBatchPublisher {
   def runProcessLoop(recordBatchConsumer: RecordBatchConsumer): RecordsPublisherRunStatus
   def initialStartingPosition: KinesisPosition
+  def currentStartingPosition: KinesisPosition
   def streamShard: StreamShard
 
   protected def getNextStartingPosition(latestSequenceNumber: SequenceNumber,

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/efo/EfoRecordBatchPublisher.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/efo/EfoRecordBatchPublisher.scala
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEvent
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.kinesis.FullJitterBackoffManager
 import org.apache.spark.sql.connector.kinesis.KinesisOptions
+import org.apache.spark.sql.connector.kinesis.AfterSequenceNumber
 import org.apache.spark.sql.connector.kinesis.KinesisPosition
 import org.apache.spark.sql.connector.kinesis.client.KinesisClientConsumer
 import org.apache.spark.sql.connector.kinesis.retrieval.RecordBatch
@@ -47,6 +48,8 @@ class EfoRecordBatchPublisher (
   val backoffManager: FullJitterBackoffManager = backoff.getOrElse(new FullJitterBackoffManager())
   var nextStartingPosition: KinesisPosition = initialStartingPosition
 
+  override def currentStartingPosition: KinesisPosition = nextStartingPosition
+
   /** The current attempt in the case of subsequent recoverable errors. */
   private var attempt = 0
 
@@ -56,7 +59,11 @@ class EfoRecordBatchPublisher (
       override def accept(event: SubscribeToShardEvent): Unit = {
         val recordBatch = RecordBatch (event.records.asScala.toSeq, streamShard, event.millisBehindLatest)
         val sequenceNumber = recordBatchConsumer.accept (recordBatch)
-        nextStartingPosition = getNextStartingPosition (sequenceNumber, nextStartingPosition)
+        if (event.records.isEmpty && event.millisBehindLatest > 0 && event.continuationSequenceNumber != null) {
+          nextStartingPosition = new AfterSequenceNumber(event.continuationSequenceNumber, -1, true)
+        } else {
+          nextStartingPosition = getNextStartingPosition(sequenceNumber, nextStartingPosition)
+        }
       }}
 
     val result = runWithBackoff(eventConsumer)

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/efo/EfoRecordBatchPublisher.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/efo/EfoRecordBatchPublisher.scala
@@ -59,6 +59,9 @@ class EfoRecordBatchPublisher (
       override def accept(event: SubscribeToShardEvent): Unit = {
         val recordBatch = RecordBatch (event.records.asScala.toSeq, streamShard, event.millisBehindLatest)
         val sequenceNumber = recordBatchConsumer.accept (recordBatch)
+        // When EFO returns empty records but millisBehindLatest > 0, our position is behind
+        // the stream tip. Use the continuationSequenceNumber to advance past the current
+        // position and avoid getting stuck in an infinite loop at AT_TIMESTAMP.
         if (event.records.isEmpty && event.millisBehindLatest > 0 && event.continuationSequenceNumber != null) {
           nextStartingPosition = new AfterSequenceNumber(event.continuationSequenceNumber, -1, true)
         } else {

--- a/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/polling/PollingRecordBatchPublisher.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/kinesis/retrieval/polling/PollingRecordBatchPublisher.scala
@@ -50,6 +50,8 @@ class PollingRecordBatchPublisher(
   // visible for test only
   var nextStartingPosition: KinesisPosition = initialStartingPosition
 
+  override def currentStartingPosition: KinesisPosition = nextStartingPosition
+
   private var nextShardItr: String = getShardIterator()
   private var processingStartTimeNanos = System.nanoTime
 

--- a/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/EfoRecordBatchPublisherSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/connector/kinesis/retrieval/EfoRecordBatchPublisherSuite.scala
@@ -755,6 +755,77 @@ class EfoRecordBatchPublisherSuite extends KinesisTestBase {
     count shouldBe 1
   }
 
+  test("Empty records with millisBehindLatest > 0 advances position via continuationSequenceNumber") {
+    // Simulate an idle shard that returns empty records but has a continuationSequenceNumber
+    val event = SubscribeToShardEvent.builder
+      .millisBehindLatest(1000L)
+      .continuationSequenceNumber("seq-42")
+      .build
+
+    val kinesisClient = singleShardWithEvents(Seq(event))
+
+    val publisher = createRecordBatchPublisher(kinesisClient,
+      KinesisPosition.make(AtTimeStamp.iteratorType,
+        DEFAULT_TIMESTAMP,
+        NO_SUB_SEQUENCE_NUMBER,
+        isLast = true
+      )
+    )
+
+    publisher.runProcessLoop(new TestConsumer(publisher.initialStartingPosition))
+
+    // Position should advance to AFTER_SEQUENCE_NUMBER using the continuationSequenceNumber
+    publisher.nextStartingPosition.iteratorType shouldBe AfterSequenceNumber.iteratorType
+    publisher.nextStartingPosition.iteratorPosition shouldBe "seq-42"
+  }
+
+  test("Empty records with millisBehindLatest == 0 does not advance position") {
+    // Shard is caught up (millisBehindLatest == 0) - no advancement needed
+    val event = SubscribeToShardEvent.builder
+      .millisBehindLatest(0L)
+      .continuationSequenceNumber("seq-99")
+      .build
+
+    val kinesisClient = singleShardWithEvents(Seq(event))
+
+    val publisher = createRecordBatchPublisher(kinesisClient,
+      KinesisPosition.make(AtTimeStamp.iteratorType,
+        DEFAULT_TIMESTAMP,
+        NO_SUB_SEQUENCE_NUMBER,
+        isLast = true
+      )
+    )
+
+    publisher.runProcessLoop(new TestConsumer(publisher.initialStartingPosition))
+
+    // Position should remain at AT_TIMESTAMP since shard is caught up
+    publisher.nextStartingPosition.iteratorType shouldBe AtTimeStamp.iteratorType
+    publisher.nextStartingPosition shouldBe publisher.initialStartingPosition
+  }
+
+  test("Empty records with null continuationSequenceNumber does not advance position") {
+    val event = SubscribeToShardEvent.builder
+      .millisBehindLatest(1000L)
+      .continuationSequenceNumber(null)
+      .build
+
+    val kinesisClient = singleShardWithEvents(Seq(event))
+
+    val publisher = createRecordBatchPublisher(kinesisClient,
+      KinesisPosition.make(AtTimeStamp.iteratorType,
+        DEFAULT_TIMESTAMP,
+        NO_SUB_SEQUENCE_NUMBER,
+        isLast = true
+      )
+    )
+
+    publisher.runProcessLoop(new TestConsumer(publisher.initialStartingPosition))
+
+    // Position should remain at AT_TIMESTAMP since no continuation available
+    publisher.nextStartingPosition.iteratorType shouldBe AtTimeStamp.iteratorType
+    publisher.nextStartingPosition shouldBe publisher.initialStartingPosition
+  }
+
   private def flattenToUserRecords(recordBatch: util.List[RecordBatch]): Seq[KinesisUserRecord] = {
     recordBatch.asScala.flatMap(_.userRecords).toSeq
   }


### PR DESCRIPTION

### What changes were proposed in this pull request? 
When the connector starts with `startingPosition=LATEST`, it internally converts to `AT_TIMESTAMP(now)`. Shards with no data at that timestamp get stuck in an infinite loop - the position never advances past the `AT_TIMESTAMP` sentinel, causing the job to hang indefinitely.

This fix addresses the issue at three layers:
1. `EfoRecordBatchPublisher`: advance position using `continuationSequenceNumber` when EFO returns empty records with `millisBehindLatest > 0`
2. `KinesisV2MicrobatchStream`: force batch creation when position is `AT_TIMESTAMP` to ensure the partition reader runs and can advance the position
3. `KinesisV2PartitionReader`: commit the publisher's advanced position, or convert stuck `AT_TIMESTAMP` to `LATEST` when no progress is made

### Why are the changes needed?
Without this fix, any EFO streaming job started from `LATEST` on a stream with idle/resharded shards will hang indefinitely. The probability approaches 100% as shard count increases. A customer was blocked for 5+ days on an 8K-shard production stream.

### Does this PR introduce any user-facing change?
No. The fix only affects internal position-advancement logic when records are empty.

### How was this patch tested?
* Reproduced the infinite loop on EMR cluster (single shard, empty stream, EFO from LATEST)
* Reproduced on multi-shard cluster (4 shards, data on 1 shard only - shards 0/2/3 stuck)
* Applied fix - verified stuck shards advance from `AT_TIMESTAMP` to `LATEST` / `AFTER_SEQUENCE_NUMBER`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*
Closes github #91 
