### PR TITLE
Fix CI: add permissions for dependency graph submission

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -20,6 +20,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### *Issue #, if available:*
NA

### *Description of changes:*
The `maven-dependency-submission-action@v4` requires `contents: write` permission to POST dependency snapshots to the GitHub API. Without an explicit `permissions` block, the workflow inherits the org/repo default which is currently read-only, causing 403 errors on every push to `main` since at least May 2026 (run for PR #92).

This change fixes the breaking CI infrastructure by adding `permissions: contents: write` at workflow level.

### *How was this patch tested:*
The CI passes successfully - https://github.com/shrirangmhalgi/spark-sql-kinesis-connector/actions/runs/28494251091/job/84457795660

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
